### PR TITLE
Add simple FastAPI expense sharing API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ apache-airflow==2.7.2
 apache-airflow-providers-apache-spark==4.1.2
 pyspark==3.5.0
 pandas==2.1.4
+fastapi==0.116.1
+uvicorn==0.35.0

--- a/src/expense_tracker.py
+++ b/src/expense_tracker.py
@@ -1,0 +1,71 @@
+from typing import Dict, List
+from pydantic import BaseModel
+
+# In-memory stores
+_users: Dict[int, "User"] = {}
+_groups: Dict[int, "Group"] = {}
+_expenses: List["Expense"] = []
+
+# Simple incrementing IDs
+def _next_id(store: Dict[int, BaseModel]) -> int:
+    return max(store.keys(), default=0) + 1
+
+class User(BaseModel):
+    id: int
+    name: str
+    email: str
+
+class Group(BaseModel):
+    id: int
+    name: str
+    members: List[int]
+
+class Expense(BaseModel):
+    id: int
+    group_id: int
+    description: str
+    amount: float
+    paid_by: int
+    splits: Dict[int, float]  # user_id -> amount owed
+
+# CRUD functions
+
+def create_user(name: str, email: str) -> User:
+    user_id = _next_id(_users)
+    user = User(id=user_id, name=name, email=email)
+    _users[user_id] = user
+    return user
+
+
+def create_group(name: str, member_ids: List[int]) -> Group:
+    group_id = _next_id(_groups)
+    group = Group(id=group_id, name=name, members=member_ids)
+    _groups[group_id] = group
+    return group
+
+
+def add_expense(group_id: int, description: str, amount: float, paid_by: int, splits: Dict[int, float]) -> Expense:
+    expense_id = len(_expenses) + 1
+    expense = Expense(
+        id=expense_id,
+        group_id=group_id,
+        description=description,
+        amount=amount,
+        paid_by=paid_by,
+        splits=splits,
+    )
+    _expenses.append(expense)
+    return expense
+
+
+def get_group_balances(group_id: int) -> Dict[int, float]:
+    balances: Dict[int, float] = {}
+    for exp in _expenses:
+        if exp.group_id != group_id:
+            continue
+        # payer contribution
+        balances[exp.paid_by] = balances.get(exp.paid_by, 0) + exp.amount
+        # subtract owed amounts
+        for uid, amt in exp.splits.items():
+            balances[uid] = balances.get(uid, 0) - amt
+    return balances

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,7 +1,15 @@
 # routes.py
-from fastapi import APIRouter, Depends
-from functions import *
+from fastapi import APIRouter
 from pydantic import BaseModel
+from typing import Dict, List
+
+from functions import *
+from expense_tracker import (
+    create_user,
+    create_group,
+    add_expense,
+    get_group_balances,
+)
 
 router = APIRouter()
 
@@ -11,4 +19,47 @@ class Query(BaseModel):  # Define a request body model
 @router.get("/docRAG/")
 async def docRAG_endpoint(query: Query):  # Accept the Query model as a parameter
     return docRAG(query.text)
+
+
+class UserIn(BaseModel):
+    name: str
+    email: str
+
+
+@router.post("/users")
+async def create_user_api(user: UserIn):
+    return create_user(user.name, user.email)
+
+
+class GroupIn(BaseModel):
+    name: str
+    members: List[int]
+
+
+@router.post("/groups")
+async def create_group_api(group: GroupIn):
+    return create_group(group.name, group.members)
+
+
+class ExpenseIn(BaseModel):
+    description: str
+    amount: float
+    paid_by: int
+    splits: Dict[int, float]
+
+
+@router.post("/groups/{group_id}/expenses")
+async def add_expense_api(group_id: int, expense: ExpenseIn):
+    return add_expense(
+        group_id,
+        expense.description,
+        expense.amount,
+        expense.paid_by,
+        expense.splits,
+    )
+
+
+@router.get("/groups/{group_id}/balances")
+async def balances_api(group_id: int):
+    return get_group_balances(group_id)
 

--- a/tests/test_expense_tracker.py
+++ b/tests/test_expense_tracker.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from expense_tracker import (
+    create_user,
+    create_group,
+    add_expense,
+    get_group_balances,
+)
+
+
+def test_balances():
+    u1 = create_user('Alice', 'alice@example.com')
+    u2 = create_user('Bob', 'bob@example.com')
+    g = create_group('Trip', [u1.id, u2.id])
+    add_expense(g.id, 'Hotel', 100, u1.id, {u1.id: 50, u2.id: 50})
+    balances = get_group_balances(g.id)
+    assert balances[u1.id] == 50  # Alice paid 100 but owes 50 -> +50
+    assert balances[u2.id] == -50


### PR DESCRIPTION
## Summary
- add a minimal expense tracking module
- expose expense CRUD endpoints via FastAPI
- include FastAPI in requirements
- basic unit test for expense calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bcf4b1450832990b3347c9bf2b30c